### PR TITLE
added 'per_page: 100' to maximize the number of assets being queri…

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ async function run() {
 		let assets = await github.repos.listAssetsForRelease({
 			owner: owner,
 			repo: repo,
-			release_id: parseInt(releaseId)
+			release_id: parseInt(releaseId),
+			per_page: 100
 		});
 
 		assets.data.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));


### PR DESCRIPTION
This PR adds the `per_page` parameter to the `listAssetsForRelease()` call. This fixes issues where deploy-nightly is used where more than 30 assets are stored in a certain `release_id`. Note, however, that for >100 assets `listAssetsForRelease()` might have to be called multiple times using the optional `page` parameter of `listAssetsForRelease()`