### PR TITLE
Add generated asset name to outputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ async function run() {
 
 		core.setOutput("uploaded", "yes");
 		core.setOutput("url", url);
+		core.setOutput("asset_name", name);
 	} catch (error) {
 		core.setFailed(error.message);
 	}


### PR DESCRIPTION
closes https://github.com/WebFreak001/deploy-nightly/issues/12

Adds `asset_name` to outputs, which exposes the fully formed asset name with date and sha