### PR TITLE
Revert "Add token, repo and sha input"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,4 @@ jobs:
           asset_name: myapp_windows-nightly-$$.zip # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash
           asset_content_type: application/zip # required by GitHub API
           max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
-          token: *** # optional, a github token. defaults to GITHUB_TOKEN
-          sha: 547fdf5 # optional, a commit SHA. Defaults to GITHUB_SHA
-          repo: Pure-D/serve-d # optional, the repository where the release is located
 ```

--- a/action.yml
+++ b/action.yml
@@ -26,18 +26,6 @@ inputs:
     description: 'Maximum number of historical releases with the given asset_name to keep'
     required: false
     default: 7
-  token:
-    description: 'The Github token.'
-    required: false
-    default: ${{ github.token }}
-  repo:
-    description: "Optionally specify the repo where the release is located. Defaults to current repo"
-    required: false
-    default: ${{ github.repository }}
-  sha:
-    description: "Optionally specify the commit SHA. Defaults to SHA that triggered the workflow"
-    required: false
-    default: ${{ github.sha }}
 
 output:
   uploaded:

--- a/index.js
+++ b/index.js
@@ -35,21 +35,23 @@ async function uploadAsset(octokit, name) {
 
 async function run() {
 	try {
-		const token = core.getInput("token", { required: false });
-		const sha = core.getInput("sha", { required: false });
-		let repo = core.getInput("repo", { required: false });
 		const maxReleases = parseInt(core.getInput("max_releases", { required: false }));
 		const releaseId = core.getInput("release_id", { required: true });
 		let name = core.getInput("asset_name", { required: true });
 		const placeholderStart = name.indexOf("$$");
 		const nameStart = name.substring(0, placeholderStart);
 		const nameEnd = name.substring(placeholderStart + 2);
-		
-		const octokit = getOctokit(token);
-		const hash = sha.substring(0, 6);
-		const repository = repo.split('/');
+
+		if (!process.env.GITHUB_TOKEN
+			|| !process.env.GITHUB_SHA
+			|| !process.env.GITHUB_REPOSITORY)
+			throw new Error("Missing required GitHub environment variables!");
+
+		const octokit = getOctokit(process.env.GITHUB_TOKEN);
+		const hash = process.env.GITHUB_SHA.substring(0, 6);
+		const repository = process.env.GITHUB_REPOSITORY.split('/');
 		const owner = repository[0];
-		repo = repository[1];
+		const repo = repository[1];
 
 		core.info("Checking previous assets");
 		let assets = await octokit.rest.repos.listReleaseAssets({


### PR DESCRIPTION
Reverts WebFreak001/deploy-nightly#23

use environment variables to customize the behavior instead:

```yml
      - name: Deploy Windows release
        if: matrix.os == 'windows-latest'
        uses: WebFreak001/deploy-nightly@v2.0.0
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided by github actions
          GITHUB_SHA: 547fdf5 # optional, a commit SHA
          GITHUB_REPOSITORY: Pure-D/serve-d # optional, the repository where the release is located
        with:
          upload_url: https://uploads.github.com/repos/Pure-D/serve-d/releases/20717582/assets{?name,label} # find out this value by opening https://api.github.com/repos/<owner>/<repo>/releases in your browser and copy the full "upload_url" value including the {?name,label} part
          release_id: 20717582 # same as above (id can just be taken out the upload_url, it's used to find old releases)
          asset_path: ./myapp.zip # path to archive to upload
          asset_name: myapp_windows-nightly-$$.zip # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash
          asset_content_type: application/zip # required by GitHub API
          max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
```