### PR TITLE
add ignore_hash argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ jobs:
           asset_name: myapp_windows-nightly-$$.zip # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash
           asset_content_type: application/zip # required by GitHub API
           max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
+          ignore_hash: true # optional, if there is already a release associated with the repo's current commit, should we go ahead and upload the asset anyway.
 ```
 
 ### Advanced Use

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Maximum number of historical releases with the given asset_name to keep'
     required: false
     default: 7
+  ignore_hash:
+    description: 'If a release asset exists associated with the current commit, upload anyway?'
+    required: false
+    default: false
   token:
     description: 'The Github token.'
     required: false

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ async function run() {
 		const sha = core.getInput("sha", { required: false });
 		const owner_repo = core.getInput("repo", { required: false });
 		const maxReleases = parseInt(core.getInput("max_releases", { required: false }));
+		const ignoreHash = core.getBooleanInput("ignore_hash", { required: false });
 		const releaseId = core.getInput("release_id", { required: true });
 		let name = core.getInput("asset_name", { required: true });
 		const placeholderStart = name.indexOf("$$");
@@ -80,7 +81,7 @@ async function run() {
 				// not commit hash or date in filename, always force upload here
 				existingAssetNameId = asset.id;
 			} else if (asset.name.startsWith(nameStart) && asset.name.endsWith(nameEnd)) {
-				if (asset.name.endsWith("-" + hash + nameEnd)) {
+				if (!ignoreHash && asset.name.endsWith("-" + hash + nameEnd)) {
 					core.info("Current commit already released, exiting");
 					core.setOutput("uploaded", "no");
 					return;


### PR DESCRIPTION
This adds an ignore_hash argument that will let an asset to be uploaded even if the parametrized asset name has a hash corresponding to an already uploaded asset. 

This is useful if the release depends on external assets not in the repo.

will close #31 

